### PR TITLE
Adds Support for Supplying Private Key Passphrase

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Playbook to import a PGP keypair might look like:
           gpg_user: "ubuntu"
           gpg_group: "ubuntu"
           gpg_private_key: "files/pgp/priv.key"
+          gpg_private_key_passphrase: "somesecret"
           gpg_public_key: "files/pgp/pub.key"
           gpg_trust_file: "files/pgp/ultimate.trust"
       roles:

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -5,3 +5,4 @@ gpg_group: "root"
 gpg_private_key:
 gpg_public_key:
 gpg_trust_file:
+gpg_private_key_passphrase: ""

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -36,7 +36,7 @@
 - name: Import private key
   become: yes
   become_user: "{{ gpg_user }}"
-  command: "gpg --allow-secret-key-import --import {{ gpg_import_directory.path }}/private.key"
+  command: "gpg --allow-secret-key-import{% if gpg_private_key_passphrase|length > 0 %} --batch --passphrase=\"{{ gpg_private_key_passphrase }}\"{% endif %} --import {{ gpg_import_directory.path }}/private.key"
   changed_when: output is defined and output.stdout != ""
   args:
     creates: "{{ gpg_home }}/.gnupg/{{ gpg_trustdb_file }}"


### PR DESCRIPTION
Since you need to input the passphrase when importing a GPG private key
that has a passphrase, this PR adds support for that.

Signed-off-by: Jason Rogena <jason@rogena.me>