### PR TITLE
Allows Private Key Reimports

### DIFF
--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,4 +1,4 @@
-gpg_home: "{{ ansible_env.HOME }}"
+gpg_home: "~"
 gpg_trustdb_file: "trustdb.gpg"
 gpg_user: "root"
 gpg_group: "root"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -37,9 +37,13 @@
   become: yes
   become_user: "{{ gpg_user }}"
   command: "gpg --allow-secret-key-import{% if gpg_private_key_passphrase|length > 0 %} --batch --passphrase=\"{{ gpg_private_key_passphrase }}\"{% endif %} --import {{ gpg_import_directory.path }}/private.key"
-  changed_when: output is defined and output.stdout != ""
-  args:
-    creates: "{{ gpg_home }}/.gnupg/{{ gpg_trustdb_file }}"
+  register: gpg_private_key_import_status
+  ignore_errors: true
+
+- name: Check if private key imported successfully
+  fail:
+    msg: "An error occurred while importing the private key"
+  when: gpg_private_key_import_status.rc != 0 and "already in secret keyring" not in gpg_private_key_import_status.stderr
 
 - name: Add trust
   become: yes


### PR DESCRIPTION
Allows private keys to be reimported by ignoring errors in the private
key import task then checking whether the error was related to GPG
complaining that the key already exists.